### PR TITLE
Add skeleton code for csp-billing-adapter-microsoft

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,6 @@ MANIFEST
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
 *.manifest
-*.spec
 
 # Installer logs
 pip-log.txt
@@ -127,3 +126,19 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Vscode
+.vscode/
+
+### PyCharm ###
+.idea/
+
+### Vim ###
+# swap
+[._]*.s[a-w][a-z]
+[._]s[a-w][a-z]
+# session
+Session.vim
+# temporary
+.netrwhist
+*i~

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,88 @@
+Installation
+============
+
+```shell
+$ git clone https://github.com/SUSE-Enceladus/csp-billing-adapter-microsoft.git
+$ cd csp-billing-adapter-microsoft
+
+# Activate virtual Environment then install
+# csp-billing-adapter-microsoft and dev dependences in editable mode
+$ pip install -e .[dev]
+```
+
+csp-billing-adapter-microsoft is now installed in the active virtual environment in development
+mode.
+
+Dev Requirements
+================
+
+- bumpversion
+
+Testing Requirements
+====================
+
+- coverage
+- flake8
+- pytest-cov
+
+Contribution Checklist
+======================
+
+- All patches must be signed. [Signing Commits](#signing-commits)
+- All contributed code must conform to flake8. [Code Style](#code-style)
+- All new code contributions must be accompanied by a test.
+    - Tests must pass and coverage remain above 90%. [Unit & Integration Tests](#unit-&-integration-tests)
+- Follow Semantic Versioning. [Versions & Releases](#versions-&-releases)
+
+Versions & Releases
+===================
+
+**csp-billing-adapter-microsoft** adheres to Semantic versioning; see <http://semver.org/> for
+details.
+
+[bumpversion](https://pypi.python.org/pypi/bumpversion/) is used for
+release version management, and is configured in `setup.cfg`:
+
+```shell
+$ bumpversion major|minor|patch
+$ git push
+```
+
+Bumpversion will create a commit with version updated in all locations.
+The annotated tag is created separately.
+
+```shell
+$ git tag -a v{version}
+# git tag -a v0.0.1
+
+# Create a message with the changes since last release and push tags.
+$ git push --tags
+```
+
+Unit & Integration Tests
+========================
+
+All tests should pass and test coverage should remain above 90%.
+
+The tests and coverage can be run directly via pytest.
+
+```shell
+$ pytest --cov=csp_billing_adapter_microsoft
+```
+
+Code Style
+==========
+
+Source should pass flake8 and pep8 standards.
+
+```shell
+$ flake8 csp_billing_adapter_microsoft
+```
+
+Signing Commits
+===============
+
+The repository and the code base patches sent for inclusion must be GPG
+signed. See the GitHub article, [Signing commits using
+GPG](https://help.github.com/articles/signing-commits-using-gpg/), for
+more information.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,12 @@
+include LICENSE
+include CONTRIBUTING.md
+include README.md
+include csp-billing-adapter-microsoft.spec
+include requirements.txt
+include requirements-test.txt
+include requirements-dev.txt
+
+recursive-include tests *
+recursive-exclude * __pycache__
+recursive-exclude * *.coverage
+recursive-exclude * *.py[co]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-# csp-billing-adapter-microsoft
+# csp billing adapter microsoft plugin
+
+This is a plugin for [csp-billing-adapter](https://github.com/SUSE-Enceladus/csp-billing-adapter) that provides hook implementations for Microsoft Azure.

--- a/csp-billing-adapter-microsoft.spec
+++ b/csp-billing-adapter-microsoft.spec
@@ -1,0 +1,67 @@
+#
+# spec file for package csp-billing-adapter-microsoft
+#
+# Copyright (c) 2023 SUSE LLC
+#
+# All modifications and additions to the file contributed by third parties
+# remain the property of their copyright owners, unless otherwise agreed
+# upon. The license for this file, and modifications and additions to the
+# file, is the same license as for the pristine package itself (unless the
+# license for the pristine package is not an Open Source License, in which
+# case the license is the MIT License). An "Open Source License" is a
+# license that conforms to the Open Source Definition (Version 1.9)
+# published by the Open Source Initiative.
+
+# Please submit bugfixes or comments via https://bugs.opensuse.org/
+#
+
+
+Name:           csp-billing-adapter-microsoft
+Version:        0.0.1
+Release:        0
+Summary:        TBD
+License:        Apache-2.0
+URL:            https://github.com/SUSE-Enceladus/%{name}
+Source:         https://files.pythonhosted.org/packages/source/c/%{name}/%{name}-%{version}.tar.gz
+BuildRequires:  python-rpm-macros
+BuildRequires:  python3-pluggy
+BuildRequires:  python3-msal
+BuildRequires:  python3-azure-identity
+BuildRequires:  csp-billing-adapter
+%if %{with test}
+BuildRequires:  python3-pytest
+BuildRequires:  python3-coverage
+BuildRequires:  python3-pytest-cov
+%endif
+Requires:       python3-pluggy
+Requires:       python3-msal
+Requires:       python3-azure-identity
+Requires:       csp-billing-adapter
+BuildArch:      noarch
+
+%description
+TBD
+
+%prep
+%autosetup -n %{name}-%{version}
+
+%build
+%python_build
+
+%install
+%python_install
+%python_expand %fdupes %{buildroot}%{$python_sitelib}
+
+%check
+%if %{with test}
+python3 -m pytest --cov=csp_billing_adapter_microsoft
+%endif
+
+%files %{python_files}
+%license LICENSE
+%doc README.md CONTRIBUTING.md
+%{python_sitelib}/%{name}
+%{python_sitelib}/%{name}-%{version}*-info
+%{_bindir}/%{name}
+
+%changelog

--- a/csp_billing_adapter_microsoft/__init__.py
+++ b/csp_billing_adapter_microsoft/__init__.py
@@ -1,0 +1,3 @@
+__author__ = """SUSE"""
+__email__ = 'public-cloud-dev@susecloud.net'
+__version__ = '0.0.1'

--- a/csp_billing_adapter_microsoft/plugin.py
+++ b/csp_billing_adapter_microsoft/plugin.py
@@ -1,0 +1,27 @@
+import csp_billing_adapter
+
+from csp_billing_adapter.config import Config
+
+
+@csp_billing_adapter.hookimpl
+def setup_adapter(config: Config):
+    pass
+
+
+@csp_billing_adapter.hookimpl(trylast=True)
+def meter_billing(
+    config: Config,
+    dimensions: dict,
+    timestamp: str,
+):
+    pass
+
+
+@csp_billing_adapter.hookimpl(trylast=True)
+def get_csp_name(config: Config):
+    return 'microsoft'
+
+
+@csp_billing_adapter.hookimpl(trylast=True)
+def get_account_info(config: Config):
+    pass

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+-r requirements-test.txt
+
+bumpversion

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,5 @@
+-r requirements.txt
+
+coverage
+flake8
+pytest-cov

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+csp-billing-adapter
+requests
+pluggy
+msal
+azure.identity

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,19 @@
+[bumpversion]
+current_version = 0.0.1
+commit = True
+tag = True
+
+[bumpversion:file:setup.py]
+
+[bumpversion:file:csp_billing_adapter_microsoft/__init__.py]
+
+[bumpversion:file:csp-billing-adapter-microsoft.spec]
+
+[tool:pytest]
+testpaths = tests
+
+[coverage:report]
+fail_under = 90
+
+[metadata]
+license_file = LICENSE

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,65 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+
+"""Setup script."""
+
+# Copyright (c) 2023 SUSE LLC
+#
+# This file is part of csp-billing-adapter-microsoft.
+
+from setuptools import setup
+
+with open('README.md') as readme_file:
+    readme = readme_file.read()
+
+with open('requirements.txt') as req_file:
+    requirements = req_file.read().splitlines()
+
+with open('requirements-test.txt') as req_file:
+    test_requirements = req_file.read().splitlines()[2:]
+
+with open('requirements-dev.txt') as req_file:
+    dev_requirements = test_requirements + req_file.read().splitlines()[2:]
+
+
+setup(
+    name='csp-billing-adapter-microsoft',
+    version='0.0.1',
+    description='TBD',
+    long_description=readme,
+    long_description_content_type='text/markdown',
+    author='SUSE',
+    author_email='public-cloud-dev@susecloud.net',
+    url='https://github.com/SUSE-Enceladus/csp-billing-adapter-microsoft',
+    entry_points={
+        'csp_billing_adapter': [
+            'microsoft = csp_billing_adapter_microsoft.plugin'
+        ]
+    },
+    packages=['csp_billing_adapter_microsoft'],
+    include_package_data=True,
+    python_requires='>=3.6',
+    install_requires=requirements,
+    extras_require={
+        'dev': dev_requirements,
+        'test': test_requirements
+    },
+    license='Apache-2.0',
+    zip_safe=False,
+    keywords='csp-billing-adapter-microsoft csp_billing_adapter_microsoft',
+    classifiers=[
+        'Development Status :: 2 - Pre-Alpha',
+        'Environment :: Console',
+        'Intended Audience :: Developers',
+        'Topic :: System :: Monitoring',
+        'License :: OSI Approved :: Apache License 2.0',
+        'Natural Language :: English',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+    ]
+)


### PR DESCRIPTION
This PR adds the skeleton code for the csp-billing-adapter-microsoft. This is a clone of the skeleton in csp-billing-adapter-amazon with a few adjustments for using microsoft as the CSP and some editor editions to the .gitignore