### PR TITLE
update spec file to match Amazon

### DIFF
--- a/csp-billing-adapter-microsoft.spec
+++ b/csp-billing-adapter-microsoft.spec
@@ -15,32 +15,36 @@
 # Please submit bugfixes or comments via https://bugs.opensuse.org/
 #
 
-
+%{?!python_module:%define python_module() python-%{**} python3-%{**}}
+%global skip_python2 1
+%define pythons python3
 Name:           csp-billing-adapter-microsoft
 Version:        0.0.1
 Release:        0
-Summary:        TBD
+Summary:        Implements Microsoft metering hooks for csp-billing-adapter
 License:        Apache-2.0
+Group:          Development/Languages/Python
 URL:            https://github.com/SUSE-Enceladus/%{name}
 Source:         https://files.pythonhosted.org/packages/source/c/%{name}/%{name}-%{version}.tar.gz
+BuildRequires:  fdupes
 BuildRequires:  python-rpm-macros
-BuildRequires:  python3-pluggy
-BuildRequires:  python3-msal
-BuildRequires:  python3-azure-identity
-BuildRequires:  csp-billing-adapter
+BuildRequires:  %{python_module setuptools}
+BuildRequires:  %{python_module pluggy}
+BuildRequires:  %{python_module csp-billing-adapter}
 %if %{with test}
-BuildRequires:  python3-pytest
-BuildRequires:  python3-coverage
-BuildRequires:  python3-pytest-cov
+BuildRequires:  %{python_module pytest}
+BuildRequires:  %{python_module coverage}
+BuildRequires:  %{python_module pytest-cov}
 %endif
+Requires:       python-setuptools
 Requires:       python3-pluggy
-Requires:       python3-msal
-Requires:       python3-azure-identity
 Requires:       csp-billing-adapter
 BuildArch:      noarch
+%python_subpackages
 
 %description
-TBD
+Provides a plugin for csp-billing-adapter to handle
+metering of usage in Microsoft Azure.
 
 %prep
 %autosetup -n %{name}-%{version}
@@ -54,14 +58,14 @@ TBD
 
 %check
 %if %{with test}
-python3 -m pytest --cov=csp_billing_adapter_microsoft
+pytest
 %endif
 
 %files %{python_files}
 %license LICENSE
 %doc README.md CONTRIBUTING.md
-%{python_sitelib}/%{name}
-%{python_sitelib}/%{name}-%{version}*-info
-%{_bindir}/%{name}
+%{python_sitelib}/csp_billing_adapter_microsoft
+%{python_sitelib}/csp_billing_adapter_microsoft*-info
+#%{python_sitelib}/csp_billing_adapter-%{version}*-info
 
 %changelog


### PR DESCRIPTION
The PR updates the spec file to match the structure and setup for the spec file used with csp-billing-adapter-amazon. 