### PR TITLE
add unit tests for metadata in plugin.py

### DIFF
--- a/csp_billing_adapter_microsoft/plugin.py
+++ b/csp_billing_adapter_microsoft/plugin.py
@@ -133,6 +133,7 @@ def _is_required_metadata_version_available():
 
     return False
 
+
 def _fetch_metadata(url):
     """Return the response of the metadata request."""
     data_request = urllib.request.Request(
@@ -149,3 +150,10 @@ def _fetch_metadata(url):
             error=str(error)
         ))
         return {}
+
+
+def _get_api_token():
+    """
+    Get the token to authenticate when using the Billing API
+   """
+    return json.loads(_fetch_metadata(TOKEN_URL))

--- a/tests/data/good_config.yaml
+++ b/tests/data/good_config.yaml
@@ -1,0 +1,29 @@
+billing_interval: monthly
+product_code: foo
+query_interval: 3600
+reporting_api_is_cumulative: true
+reporting_interval: 3600
+usage_metrics:
+  managed_node_count:
+    consumption_reporting: volume
+    dimensions:
+    - dimension: tier_1
+      min: 0
+      max: 15
+    - dimension: tier_2
+      min: 16
+      max: 50
+    - dimension: tier_3
+      min: 51
+      max: 100
+    - dimension: tier_4
+      min: 101
+      max: 250
+    - dimension: tier_5
+      min: 251
+      max: 1000
+    - dimension: tier_6
+      min: 1001
+    min_consumption: 5
+    usage_aggregation: average
+version: 1.1.1

--- a/tests/unit/test_plugin.py
+++ b/tests/unit/test_plugin.py
@@ -1,0 +1,138 @@
+#
+# Copyright 2023 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import pytest
+import urllib.error
+
+from unittest.mock import Mock, patch
+
+from csp_billing_adapter_microsoft import plugin
+from csp_billing_adapter.config import Config
+from csp_billing_adapter.adapter import get_plugin_manager
+import csp_billing_adapter.exceptions as cba_exceptions
+
+
+pm = get_plugin_manager()
+config = Config.load_from_file(
+    'tests/data/good_config.yaml',
+    pm.hook
+)
+
+
+@patch(
+    'csp_billing_adapter_microsoft.plugin.'
+    '_is_required_metadata_version_available'
+)
+def test_setup(mock_check_metadata_version):
+    mock_check_metadata_version.return_value = True
+    plugin.setup_adapter(config)  # Currently no-op
+
+
+@pytest.mark.skipif(not hasattr(cba_exceptions, 'MetadataCollectorError'),
+                    reason='MetadataCollectorError not defined yet')
+@patch(
+    'csp_billing_adapter_microsoft.plugin.'
+    '_is_required_metadata_version_available'
+)
+def test_setup_adapter_fails(mock_check_metadata_version):
+    mock_check_metadata_version.return_value = False
+    with pytest.raises(cba_exceptions.MetadataCollectorError):
+        plugin.setup_adapter(config)  # Cur
+
+
+def test_meter_billing():
+    pass
+
+
+def test_meter_billing_error():
+    pass
+
+
+def test_get_csp_name():
+    assert plugin.get_csp_name(config) == 'microsoft'
+
+
+@patch('csp_billing_adapter_microsoft.plugin.urllib.request.urlopen')
+def test_get_account_info(mock_urlopen):
+    urlopen = Mock()
+    urlopen.read.side_effect = [
+        b'{"compute": "info", "network": "info"}',
+        b'{"signature": "signature", "pkcs7": "pkcs7"}'
+    ]
+    mock_urlopen.return_value = urlopen
+
+    info = plugin.get_account_info(config)
+    assert info == {
+        'compute': 'info',
+        'network': 'info',
+        'attestedData': {'pkcs7': 'pkcs7', 'signature': 'signature'},
+        'cloud_provider': 'microsoft',
+    }
+
+
+@patch('csp_billing_adapter_microsoft.plugin.urllib.request.urlopen')
+def test_fetch_metadata_fail(mock_urlopen):
+    urlopen = Mock()
+    urlopen.read.side_effect = [
+        urllib.error.URLError('Cannot get metadata!')
+    ]
+    mock_urlopen.return_value = urlopen
+
+    metadata = plugin._fetch_metadata('http://foo.abc.org')
+    assert metadata == {}
+
+
+@patch('csp_billing_adapter_microsoft.plugin._get_instance_metadata')
+@patch('csp_billing_adapter_microsoft.plugin._get_signature')
+def test_get_metadata_fail(mock_get_signature, mock_get_instance_metadata):
+    mock_get_instance_metadata.side_effect = ValueError('foo')
+    mock_get_signature.side_effect = ValueError('foo')
+
+    metadata = plugin._get_metadata()
+    assert metadata == {'attestedData': {}, 'compute': {}, 'network': {}}
+
+
+@patch('csp_billing_adapter_microsoft.plugin._fetch_metadata')
+@patch('csp_billing_adapter_microsoft.plugin.json.loads')
+def test_is_required_metadata_version_available_is_true(
+    mock_json_loads, mock_fetch_metadata
+):
+    mock_json_loads.return_value = {'apiVersions': ['2020-09-01']}
+    assert plugin._is_required_metadata_version_available() is True
+
+
+@patch('csp_billing_adapter_microsoft.plugin._fetch_metadata')
+@patch('csp_billing_adapter_microsoft.plugin.json.loads')
+def test_is_required_metadata_version_available_is_false(
+    mock_json_loads, mock_fetch_metadata
+):
+    mock_json_loads.return_value = {'apiVersions': ['2021-09-01']}
+    assert plugin._is_required_metadata_version_available() is False
+
+
+@patch('csp_billing_adapter_microsoft.plugin.urllib.request.urlopen')
+def test_get_api_token(mock_urlopen):
+    urlopen = Mock()
+    urlopen.read.side_effect = [
+        b'{"access_token": "info", "expires_in": "info"}'
+    ]
+    mock_urlopen.return_value = urlopen
+
+    info = plugin._get_api_token()
+    assert info == {
+        'access_token': 'info',
+        'expires_in': 'info'
+    }


### PR DESCRIPTION
This PR adds unit tests for the functions that currently exist in the plugin.py.

```
---------- coverage: platform linux, python 3.10.11-final-0 ----------
Name                                        Stmts   Miss  Cover
---------------------------------------------------------------
csp_billing_adapter_microsoft/__init__.py       3      0   100%
csp_billing_adapter_microsoft/plugin.py        62      1    98%
setup.py                                       11     11     0%
tests/unit/test_plugin.py                      64      3    95%
---------------------------------------------------------------
TOTAL                                         140     15    89%
```
One test is currently skipped until https://github.com/SUSE-Enceladus/csp-billing-adapter/pull/106 is merged.

In addition, the get_api_token() function and test case are added. This function just calls the existing `_fetch_metadata` with the correct URL (TOKEN_URL, already in defined in plugin.py)  for retrieving an authentication token needed when the meter_billing() is implemented.

https://learn.microsoft.com/en-us/partner-center/marketplace/azure-container-metered-billing#metered-billing-single-usage-event