### PR TITLE
Fix pytest config is setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,7 @@ testpaths = tests
 
 [coverage:report]
 fail_under = 90
+show_missing = True
 
 [metadata]
 license_file = LICENSE


### PR DESCRIPTION
This adds the correct entries for pytest in the setup.cfg file. (similar to what is use for google)

```
 pytest --cov=csp_billing_adapter_microsoft
====================================================================== test session starts ======================================================================
platform linux -- Python 3.10.11, pytest-7.3.2, pluggy-1.0.0
rootdir: /home/kberger/repos/github/csp/csp-billing-adapter-microsoft
configfile: setup.cfg
testpaths: tests
plugins: cov-4.1.0
collected 11 items

tests/unit/test_plugin.py .s.........                                                                                                                     [100%]

---------- coverage: platform linux, python 3.10.11-final-0 ----------
Name                                        Stmts   Miss  Cover   Missing
-------------------------------------------------------------------------
csp_billing_adapter_microsoft/__init__.py       3      0   100%
csp_billing_adapter_microsoft/plugin.py        62      1    98%   54
-------------------------------------------------------------------------
TOTAL                                          65      1    98%

Required test coverage of 90.0% reached. Total coverage: 98.46%

================================================================= 10 passed, 1 skipped in 0.19s =================================================================
```