### PR TITLE
Update plugin and unit test to use new exception type.

### DIFF
--- a/csp_billing_adapter_microsoft/plugin.py
+++ b/csp_billing_adapter_microsoft/plugin.py
@@ -51,7 +51,7 @@ def setup_adapter(config: Config):
     """Handle any plugin specific setup at adapter start"""
     is_available = _is_required_metadata_version_available()
     if not is_available:
-        raise cba_exceptions.MetadataCollectorError(
+        raise cba_exceptions.CSPMetadataRetrievalError(
             "Running in Azure context with insufficient IMDS API version"
         )
 

--- a/tests/unit/test_plugin.py
+++ b/tests/unit/test_plugin.py
@@ -41,15 +41,13 @@ def test_setup(mock_check_metadata_version):
     plugin.setup_adapter(config)  # Currently no-op
 
 
-@pytest.mark.skipif(not hasattr(cba_exceptions, 'MetadataCollectorError'),
-                    reason='MetadataCollectorError not defined yet')
 @patch(
     'csp_billing_adapter_microsoft.plugin.'
     '_is_required_metadata_version_available'
 )
 def test_setup_adapter_fails(mock_check_metadata_version):
     mock_check_metadata_version.return_value = False
-    with pytest.raises(cba_exceptions.MetadataCollectorError):
+    with pytest.raises(cba_exceptions.CSPMetadataRetrievalError):
         plugin.setup_adapter(config)  # Cur
 
 


### PR DESCRIPTION
The PR updates plugin.py and test_plugin.py to use the new exception, CSPMetadataRetrievalError added in https://github.com/SUSE-Enceladus/csp-billing-adapter/pull/106. Prior to this change, the test for this was skipped .

```
pytest --cov=csp_billing_adapter_microsoft
====================================================================== test session starts ======================================================================
platform linux -- Python 3.10.11, pytest-7.3.2, pluggy-1.0.0
rootdir: /home/kberger/repos/github/csp/csp-billing-adapter-microsoft
configfile: setup.cfg
testpaths: tests
plugins: cov-4.1.0
collected 11 items

tests/unit/test_plugin.py ...........                                                                                                                     [100%]

---------- coverage: platform linux, python 3.10.11-final-0 ----------
Name                                        Stmts   Miss  Cover   Missing
-------------------------------------------------------------------------
csp_billing_adapter_microsoft/__init__.py       3      0   100%
csp_billing_adapter_microsoft/plugin.py        62      0   100%
-------------------------------------------------------------------------
TOTAL                                          65      0   100%

Required test coverage of 90.0% reached. Total coverage: 100.00%

====================================================================== 11 passed in 0.17s =======================================================================
```