### PR TITLE
Add github workflows now that there are unit tests in place

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -1,0 +1,54 @@
+name: Continuous testing & Linting
+
+on: [push]
+
+jobs:
+  test36:
+
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        python-version: [3.6]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e .[dev]
+    - name: Lint with flake8
+      run: |
+        flake8 csp_billing_adapter_microsoft
+        flake8 tests
+    - name: Test with pytest
+      run: |
+        pytest --cov=csp_billing_adapter_microsoft
+  
+  testall:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.7, 3.8, 3.9, "3.10", 3.11]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e .[dev]
+    - name: Lint with flake8
+      run: |
+        flake8 csp_billing_adapter_microsoft
+        flake8 tests
+    - name: Test with pytest
+      run: |
+        pytest --cov=csp_billing_adapter_microsoft

--- a/.github/workflows/obs-publish.yml
+++ b/.github/workflows/obs-publish.yml
@@ -1,0 +1,23 @@
+name: Publish Python Package To OBS
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout action repo
+        uses: actions/checkout@v2
+        with:
+          repository: suse-enceladus/.github
+      - name: Invoke deployment hook
+        uses: ./actions/webhook-action
+        env:
+          webhook_url: ${{ secrets.WEBHOOK_URL }}
+          webhook_secret: ${{ secrets.WEBHOOK_SECRET }}


### PR DESCRIPTION
This PR adds GitHub workflows to csp-billing-adapter-microsoft. This is similar to the setup on csp-billing-adapter-google.