### PR TITLE
Implement meter_billing() for Azure and corresponding test cases

### DIFF
--- a/csp_billing_adapter_microsoft/plugin.py
+++ b/csp_billing_adapter_microsoft/plugin.py
@@ -21,13 +21,15 @@ metered billing of product usage in the Azure.
 
 import json
 import logging
+import os
 import urllib.request
 import urllib.error
+import uuid
+
+from datetime import datetime
 
 import csp_billing_adapter
 import csp_billing_adapter.exceptions as cba_exceptions
-
-from datetime import datetime
 
 from csp_billing_adapter.config import Config
 
@@ -36,13 +38,10 @@ log = logging.getLogger('CSPBillingAdapter')
 METADATA_URL = 'http://169.254.169.254/metadata/'
 # We want the attested data, this is the version that supports that endpoint
 REQUIRED_METADATA_VERSION = '2020-09-01'
-METADATA_TOKEN = ('/identity/oauth2/token?api-version=' +
-                  REQUIRED_METADATA_VERSION +
-                  '&resource=https://management.azure.com/')
 
-TOKEN_URL = METADATA_URL + METADATA_TOKEN
-SIGNATURE_URL = (METADATA_URL + 'attested/document?api-version='
-                 + REQUIRED_METADATA_VERSION)
+SIGNATURE_URL = (
+    f"{METADATA_URL}attested/document?api-version={REQUIRED_METADATA_VERSION}"
+)
 METADATA_HEADER = {'Metadata': 'True'}
 
 
@@ -72,6 +71,59 @@ def meter_billing(
     calling scope.
     """
 
+    status = {}
+    usage = _create_usage_list(dimensions, timestamp)
+
+    if len(usage) > 0:
+        data_request = urllib.request.Request(
+            'https://marketplaceapi.microsoft.com/api/batchUsageEvent'
+            '?api-version=2018-08-31',
+            data=json.dumps({"request": usage}).encode("utf-8"),
+            headers={
+                'Content-type': 'application/json',
+                'x-ms-correlationid': str(uuid.uuid4()),
+                'authorization': _get_msi_token()
+            },
+            method='POST'
+        )
+
+        retries = 3
+        exc = None
+        response = None
+
+        while retries > 0:
+            try:
+                with urllib.request.urlopen(data_request) as url_open_return:
+                    response = json.loads(
+                        url_open_return.read().decode("utf-8")
+                    )
+                    break
+            except urllib.error.URLError as error:
+                exc = error
+                retries -= 1
+                continue
+
+        if exc:
+            msg = (
+                f"Failed to meter bill dimensions "
+                f"{dimensions}: {str(exc)}"
+            )
+            for dimension_name in dimensions:
+                status[dimension_name] = {
+                    "status": "failed",
+                    "error": msg
+                }
+            log.error(msg)
+            return status
+
+        if response and (response.get("count", 0) > 0):
+            return _create_status_dict(response)
+
+    log.info(
+        'Nothing to meter bill: No dimensions have non zero quantity values'
+    )
+    return status
+
 
 @csp_billing_adapter.hookimpl(trylast=True)
 def get_csp_name(config: Config):
@@ -99,7 +151,7 @@ def _get_metadata():
         metadata = _get_instance_metadata()
         metadata['attestedData'] = _get_signature()
     except ValueError as error:
-        log.error('Could not load JSON from metadata: {}'.format(error))
+        log.error('Could not load JSON from metadata %s:', error)
         for key in ['compute', 'network', 'attestedData']:
             if key not in metadata:
                 metadata[key] = {}
@@ -109,8 +161,8 @@ def _get_metadata():
 
 def _get_instance_metadata():
     """Return all compute and network information from metadata."""
-    instance_info_url = (METADATA_URL + 'instance?api-version='
-                         + REQUIRED_METADATA_VERSION)
+    instance_info_url = \
+        f'{METADATA_URL}instance?api-version={REQUIRED_METADATA_VERSION}'
     return json.loads(
         _fetch_metadata(instance_info_url)
     )
@@ -127,11 +179,8 @@ def _is_required_metadata_version_available():
     """
     Check if the metadata version we want is available
     """
-    versions = json.loads(_fetch_metadata(METADATA_URL + 'versions'))
-    if REQUIRED_METADATA_VERSION in versions.get('apiVersions', []):
-        return True
-
-    return False
+    versions = json.loads(_fetch_metadata(f"{METADATA_URL}versions"))
+    return REQUIRED_METADATA_VERSION in versions.get('apiVersions', [])
 
 
 def _fetch_metadata(url):
@@ -142,18 +191,88 @@ def _fetch_metadata(url):
         method='GET'
     )
     try:
-        value = urllib.request.urlopen(data_request).read()
-        return value.decode()
+        with urllib.request.urlopen(data_request) as value:
+            return value.read().decode("utf-8")
     except urllib.error.URLError as error:
-        log.error('Failed to retrieve metadata for: {url}. {error}'.format(
-            url=url,
-            error=str(error)
-        ))
-        return {}
+        log.error('Failed to retrieve metadata for: %s: %s', url, str(error))
+        return "{}"
 
 
-def _get_api_token():
-    """
-    Get the token to authenticate when using the Billing API
-   """
-    return json.loads(_fetch_metadata(TOKEN_URL))
+def _get_msi_token():
+    """Get the MSI token to authenticate when using the Billing API"""
+    # https://learn.microsoft.com/en-us/partner-center/marketplace/marketplace-metering-service-authentication
+
+    # Set resource id to the required value needed to to retrieve an
+    # MSI Authentication Token
+    resource = '20e940b3-4c77-4b0b-9a53-9e16a1b010a7'
+    client_id = os.environ['CLIENT_ID']
+    url = (
+        f"{METADATA_URL}"
+        f"identity/oauth2/token?api-version=2018-02-01&client_id={client_id}"
+        f"&resource={resource}"
+    )
+    try:
+        auth_token = json.loads(_fetch_metadata(url))
+
+        if auth_token["token_type"] == "Bearer" and auth_token["access_token"]:
+            return f'Bearer {auth_token["access_token"]}'
+
+        log.error('Invalid MSI token retrieved: %s', auth_token)
+        raise cba_exceptions.CSPBillingAdapterException
+    except ValueError as error:
+        log.error('Unable to acquire an MSI token %s:', str(error))
+        raise cba_exceptions.CSPBillingAdapterException from error
+
+
+def _create_usage_list(dimensions: dict, timestamp: datetime):
+    """Create the usage list used with the batchEventUsage API"""
+
+    usage = []
+    for dimension_name, quantity in dimensions.items():
+        if quantity == 0:
+            log.info(
+                'A "0" value was reported for %s, skipping meter billing',
+                dimension_name
+            )
+            continue
+
+        # Setup request body for the usage event API
+        usage.append(
+            {
+                'resourceUri': os.environ['EXTENSION_RESOURCE_ID'],
+                'quantity': quantity,
+                'dimension': dimension_name,
+                'effectiveStartTime': str(timestamp),
+                'planId': os.environ['PLAN_ID']
+            }
+        )
+    return usage
+
+
+def _create_status_dict(response: dict):
+    """Create the status dict from the response from the batchUsageEvent API"""
+    status = {}
+    for resp in response["result"]:
+        if resp.get("status") == "Accepted":
+            dim_status = {
+                "record_id": resp.get("usageEventId", None),
+                "status": "submitted"
+            }
+            log.info(
+                'New metered billing record added with ID %s:',
+                dim_status["record_id"]
+            )
+        else:
+            log.error(
+                'Unable to log metered billing record: %s',
+                resp
+            )
+            dim_status = {
+                "status": "failed",
+                "error":
+                    f'Failed to meter bill dimensions: '
+                    f'Status: {resp.get("status")} '
+                    f'Message: {resp.get("error", {}).get("message")}'
+            }
+        status[resp["dimension"]] = dim_status
+    return status

--- a/tests/unit/test_plugin.py
+++ b/tests/unit/test_plugin.py
@@ -14,10 +14,14 @@
 # limitations under the License.
 #
 
+import datetime
+import json
+import logging
+import os
 import pytest
 import urllib.error
 
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, MagicMock, patch
 
 from csp_billing_adapter_microsoft import plugin
 from csp_billing_adapter.config import Config
@@ -51,25 +55,262 @@ def test_setup_adapter_fails(mock_check_metadata_version):
         plugin.setup_adapter(config)  # Cur
 
 
-def test_meter_billing():
-    pass
+@patch.dict(os.environ, {'EXTENSION_RESOURCE_ID': 'foo', 'PLAN_ID': 'foo'})
+@patch('csp_billing_adapter_microsoft.plugin._get_msi_token')
+@patch('csp_billing_adapter_microsoft.plugin.urllib.request.urlopen')
+def test_meter_billing(mock_urlopen, mock_get_msi_token, caplog):
+    urlopen = MagicMock()
+    urlopen.read.side_effect = [
+        json.dumps({
+            "count": 2,
+            "result": [
+                {
+                    "usageEventId": "1000",
+                    "resourceUri": "foo",
+                    "quantity": 10,
+                    "dimension": "tier_1",
+                    "planId": "foo",
+                    "status": "Accepted"
+                },
+                {
+                    "usageEventId": "1001",
+                    "resourceUri": "foo",
+                    "quantity": 5,
+                    "dimension": "tier_2",
+                    "planId": "foo",
+                    "status": "Accepted"
+                }
+            ]
+        }).encode("utf-8")
+    ]
+    mock_get_msi_token.return_value = "Bearer 123456789"
+
+    urlopen.__enter__.return_value = urlopen
+    mock_urlopen.return_value = urlopen
+    caplog.set_level(logging.INFO)
+
+    dimensions = {'tier_1': 10, 'tier_2': 5}
+    timestamp = datetime.datetime.now(datetime.timezone.utc)
+
+    mock_urlopen.return_value = urlopen
+    usage_id = plugin.meter_billing(
+        config,
+        dimensions,
+        timestamp,
+        dry_run=False
+    )
+    assert usage_id["tier_1"] == {"record_id": "1000", "status": "submitted"}
+    assert "New metered billing record added" in caplog.records[0].msg
 
 
-def test_meter_billing_error():
-    pass
+@patch.dict(os.environ, {'EXTENSION_RESOURCE_ID': 'foo', 'PLAN_ID': 'foo'})
+@patch('csp_billing_adapter_microsoft.plugin._get_msi_token')
+@patch('csp_billing_adapter_microsoft.plugin.urllib.request.urlopen')
+def test_meter_billing_urllib_error(mock_urlopen, mock_get_msi_token):
+    """ Test urllib error"""
+    urlopen = MagicMock()
+    urlopen.read.side_effect = [
+        urllib.error.URLError('Cannot get metadata!'),
+        urllib.error.URLError('Cannot get metadata!'),
+        urllib.error.URLError('Cannot get metadata!')
+    ]
+    mock_get_msi_token.return_value = {
+            "Bearer 123456789"
+    }
+
+    urlopen.__enter__.return_value = urlopen
+    mock_urlopen.return_value = urlopen
+
+    dimensions = {'tier_1': 10}
+    timestamp = datetime.datetime.now(datetime.timezone.utc)
+
+    mock_urlopen.return_value = urlopen
+    usage = plugin.meter_billing(config, dimensions, timestamp, dry_run=False)
+    assert usage["tier_1"] == {
+        'status': 'failed',
+        'error': "Failed to meter bill dimensions {'tier_1': 10}: "
+        "<urlopen error Cannot get metadata!>"
+    }
+
+
+@patch.dict(os.environ, {'EXTENSION_RESOURCE_ID': 'foo', 'PLAN_ID': 'foo'})
+@patch('csp_billing_adapter_microsoft.plugin._get_msi_token')
+@patch('csp_billing_adapter_microsoft.plugin.urllib.request.urlopen')
+def test_meter_billing_quantity_is_zero(
+    mock_urlopen,
+    mock_get_msi_token,
+    caplog
+):
+    """ Test when a 0 is passed as the quantity"""
+    urlopen = Mock()
+    urlopen.read.side_effect = [
+        urllib.error.URLError('Cannot get metadata!'),
+        urllib.error.URLError('Cannot get metadata!'),
+        urllib.error.URLError('Cannot get metadata!')
+    ]
+    mock_get_msi_token.return_value = {
+            "Bearer 123456789"
+    }
+
+    mock_urlopen.return_value = urlopen
+    caplog.set_level(logging.INFO)
+
+    dimensions = {'tier_1': 0}
+    timestamp = datetime.datetime.now(datetime.timezone.utc)
+
+    mock_urlopen.return_value = urlopen
+    assert plugin.meter_billing(
+        config,
+        dimensions,
+        timestamp,
+        dry_run=False
+    ) == {}
+
+    assert 'A "0" value was reported for' in caplog.records[0].msg
+    assert \
+        "Nothing to meter bill: No dimensions have non zero quantity values" \
+        in caplog.records[1].msg
+
+
+@patch.dict(os.environ, {'EXTENSION_RESOURCE_ID': 'foo', 'PLAN_ID': 'foo'})
+@patch('csp_billing_adapter_microsoft.plugin._get_msi_token')
+@patch('csp_billing_adapter_microsoft.plugin.urllib.request.urlopen')
+def test_meter_billing_non_accepted_status_from_batchUsageEvent(
+    mock_urlopen,
+    mock_get_msi_token,
+    caplog
+):
+    """Test for a non accepted status"""
+    urlopen = MagicMock()
+    urlopen.read.side_effect = [
+        json.dumps({
+            "count": 1,
+            "result": [
+                {
+                    "status": "Duplicate",
+                    "error": {
+                        "additionalInfo": {
+                            "acceptedMessage": {
+                                "usageEventId": "1000",
+                                "status": "Duplicate",
+                                "resourceUri": "foo",
+                                "quantity": 10.0,
+                                "dimension": "tier_1",
+                                "planId": "foo"
+                            }
+                        },
+                        "message": "This usage event already exist.",
+                        "code": "Conflict"
+                    },
+                    "resourceUri": "1001",
+                    "quantity": 10.0,
+                    "dimension": "tier_1",
+                    "planId": "foo"
+                }
+            ]
+        }).encode("utf-8")
+    ]
+    mock_get_msi_token.return_value = {
+            "Bearer 123456789"
+    }
+
+    urlopen.__enter__.return_value = urlopen
+    mock_urlopen.return_value = urlopen
+
+    dimensions = {'tier_1': 10, 'tier_2': 5}
+    timestamp = datetime.datetime.now(datetime.timezone.utc)
+
+    mock_urlopen.return_value = urlopen
+    test_record = plugin.meter_billing(
+        config,
+        dimensions,
+        timestamp,
+        dry_run=False
+    )
+    assert test_record["tier_1"].get("record_id") is None
+    assert test_record["tier_1"].get("status") == 'failed'
+    assert test_record["tier_1"].get("error") == (
+        'Failed to meter bill dimensions: Status: '
+        'Duplicate Message: This usage event already exist.'
+    )
+    assert "Unable to log metered billing record" in caplog.records[0].msg
+
+
+@patch.dict(os.environ, {'EXTENSION_RESOURCE_ID': 'foo', 'PLAN_ID': 'foo'})
+@patch('csp_billing_adapter_microsoft.plugin._get_msi_token')
+@patch('csp_billing_adapter_microsoft.plugin.urllib.request.urlopen')
+def test_meter_billing_missing_keys_in_response_from_batchUsageEvent(
+    mock_urlopen,
+    mock_get_msi_token,
+    caplog
+):
+    """Test for a non accepted status"""
+    urlopen = MagicMock()
+    urlopen.read.side_effect = [
+        json.dumps({
+            "count": 1,
+            "result": [
+                {
+                    "error": {
+                        "additionalInfo": {
+                            "acceptedMessage": {
+                                "usageEventId": "1000",
+                                "status": "Duplicate",
+                                "resourceUri": "foo",
+                                "quantity": 10.0,
+                                "dimension": "tier_1",
+                                "planId": "foo"
+                            }
+                        },
+                        "code": "Conflict"
+                    },
+                    "resourceUri": "1001",
+                    "quantity": 10.0,
+                    "dimension": "tier_1",
+                    "planId": "foo"
+                }
+            ]
+        }).encode("utf-8")
+    ]
+    mock_get_msi_token.return_value = {
+            "Bearer 123456789"
+    }
+
+    urlopen.__enter__.return_value = urlopen
+    mock_urlopen.return_value = urlopen
+
+    dimensions = {'tier_1': 10, 'tier_2': 5}
+    timestamp = datetime.datetime.now(datetime.timezone.utc)
+
+    mock_urlopen.return_value = urlopen
+    test_record = plugin.meter_billing(
+        config,
+        dimensions,
+        timestamp,
+        dry_run=False
+    )
+
+    assert test_record["tier_1"].get("status") == "failed"
+    assert test_record["tier_1"].get("error") == (
+        'Failed to meter bill dimensions: Status: '
+        'None Message: None'
+    )
 
 
 def test_get_csp_name():
+    """Test getting csp name"""
     assert plugin.get_csp_name(config) == 'microsoft'
 
 
 @patch('csp_billing_adapter_microsoft.plugin.urllib.request.urlopen')
 def test_get_account_info(mock_urlopen):
-    urlopen = Mock()
+    """Test getting account info"""
+    urlopen = MagicMock()
     urlopen.read.side_effect = [
         b'{"compute": "info", "network": "info"}',
         b'{"signature": "signature", "pkcs7": "pkcs7"}'
     ]
+    urlopen.__enter__.return_value = urlopen
     mock_urlopen.return_value = urlopen
 
     info = plugin.get_account_info(config)
@@ -83,19 +324,22 @@ def test_get_account_info(mock_urlopen):
 
 @patch('csp_billing_adapter_microsoft.plugin.urllib.request.urlopen')
 def test_fetch_metadata_fail(mock_urlopen):
-    urlopen = Mock()
+    """Test unable to reach metadata service"""
+    urlopen = MagicMock()
     urlopen.read.side_effect = [
         urllib.error.URLError('Cannot get metadata!')
     ]
+    urlopen.__enter__.return_value = urlopen
     mock_urlopen.return_value = urlopen
 
     metadata = plugin._fetch_metadata('http://foo.abc.org')
-    assert metadata == {}
+    assert metadata == "{}"
 
 
 @patch('csp_billing_adapter_microsoft.plugin._get_instance_metadata')
 @patch('csp_billing_adapter_microsoft.plugin._get_signature')
 def test_get_metadata_fail(mock_get_signature, mock_get_instance_metadata):
+    """Test no metadata returned"""
     mock_get_instance_metadata.side_effect = ValueError('foo')
     mock_get_signature.side_effect = ValueError('foo')
 
@@ -108,6 +352,7 @@ def test_get_metadata_fail(mock_get_signature, mock_get_instance_metadata):
 def test_is_required_metadata_version_available_is_true(
     mock_json_loads, mock_fetch_metadata
 ):
+    """Test metadata version exists"""
     mock_json_loads.return_value = {'apiVersions': ['2020-09-01']}
     assert plugin._is_required_metadata_version_available() is True
 
@@ -117,20 +362,58 @@ def test_is_required_metadata_version_available_is_true(
 def test_is_required_metadata_version_available_is_false(
     mock_json_loads, mock_fetch_metadata
 ):
+    """Test metadata version dos not exist"""
     mock_json_loads.return_value = {'apiVersions': ['2021-09-01']}
     assert plugin._is_required_metadata_version_available() is False
 
 
+@patch('csp_billing_adapter_microsoft.plugin.os.environ')
 @patch('csp_billing_adapter_microsoft.plugin.urllib.request.urlopen')
-def test_get_api_token(mock_urlopen):
-    urlopen = Mock()
+def test_get_msi_token(mock_urlopen, mock_os_environ):
+    """Test get token for metadata service"""
+    urlopen = MagicMock()
+
     urlopen.read.side_effect = [
-        b'{"access_token": "info", "expires_in": "info"}'
+        b'{"access_token": "123456789", "token_type": "Bearer"}'
     ]
+
+    urlopen.__enter__.return_value = urlopen
+    mock_urlopen.return_value = urlopen
+    mock_os_environ.return_value = "12345"
+
+    info = plugin._get_msi_token()
+    assert info == "Bearer 123456789"
+
+
+@patch('csp_billing_adapter_microsoft.plugin.os.environ')
+@patch('csp_billing_adapter_microsoft.plugin.urllib.request.urlopen')
+def test_get_msi_token_error(mock_urlopen, mock_os_environ, caplog):
+    """Test error getting token"""
+    urlopen = MagicMock()
+    urlopen.read.side_effect = ValueError()
+
+    urlopen.__enter__.return_value = urlopen
     mock_urlopen.return_value = urlopen
 
-    info = plugin._get_api_token()
-    assert info == {
-        'access_token': 'info',
-        'expires_in': 'info'
-    }
+    with pytest.raises(cba_exceptions.CSPBillingAdapterException):
+        plugin._get_msi_token()
+
+    assert "Unable to acquire an MSI token" in caplog.records[0].msg
+
+
+@patch('csp_billing_adapter_microsoft.plugin.os.environ')
+@patch('csp_billing_adapter_microsoft.plugin.urllib.request.urlopen')
+def test_get_msi_token_invalid(mock_urlopen, mock_os_environ, caplog):
+    """Test Invalid token received"""
+    urlopen = MagicMock()
+    urlopen.read.side_effect = [
+        b'{"access_token": "123456789", "token_type": "Foo"}'
+    ]
+
+    urlopen.__enter__.return_value = urlopen
+    mock_urlopen.return_value = urlopen
+
+    with pytest.raises(cba_exceptions.CSPBillingAdapterException):
+        plugin._get_msi_token()
+
+    assert "Invalid MSI token retrieved" in caplog.records[0].msg


### PR DESCRIPTION
This is the draft implementation (based on documentation and not testing a live offer) of implementing the meter_billing() function.  

This function follows the guidelines and examples posted at:

https://github.com/Azure-Samples/kubernetes-offer-samples/blob/main/samples/k8s-offer-azure-vote-custom-meters/azure-vote-custom/src/main.py

Currently, the function is using the batchEventUsage API to allow submission of all dimensions in one API call.  The function removes any dimensions with a "0" value as those are not valid per:

https://learn.microsoft.com/en-us/partner-center/marketplace/azure-container-metered-billing#azure-container-metered-billing

This function will pull in several environment variables that set by the helm chart's value.yaml when the offer is deployed.

https://learn.microsoft.com/en-us/partner-center/marketplace/azure-container-technical-assets-kubernetes?tabs=linux

This implementation will not retry an individual usageEvent for a dimension that has a non "Accepted" status..  When examining the values, several of the possible errors preclude a resubmission for an individual dimension. For example,  Duplicate or Expired. The other errors would occur for all dimensions and this would result in nothing being logged. In this case the return status dictionary  would be "failed" for all dimensions.  For other cases where some X in the batch are submitted successfully and some Y fail, the return status dictionary  will consist of both "submitted" and "failed' entries for the corresponding dimension.  For any record that does not have an "Accepted" status, a error message is logged as well.

Test data from a running instance suing simulated data with quantiries:

tier_1: 1
tier_2:  1


>>> print(metered_billing_data)
{'request': [{'resourceUri': '/subscriptions/5f40eec9-a9be-4851-90c1-621e6d65df81/resourceGroups/kberger/providers/Microsoft.ContainerService/managedclusters/kberger-test-aks-cluster/providers/Microsoft.KubernetesConfiguration/extensions/kbergervoteapp', 'quantity': 1, 'dimension': 'tier_1', 'effectiveStartTime': '2023-07-27 19:13:42.772725', 'planId': 'kberger-nv-custom-silver'}, {'resourceUri': '/subscriptions/5f40eec9-a9be-4851-90c1-621e6d65df81/resourceGroups/kberger/providers/Microsoft.ContainerService/managedclusters/kberger-test-aks-cluster/providers/Microsoft.KubernetesConfiguration/extensions/kbergervoteapp', 'quantity': 1, 'dimension': 'tier_2', 'effectiveStartTime': '2023-07-27 19:14:35.469159', 'planId': 'kberger-nv-custom-silver'}]}

>>> print(status)
{'tier_1': {'record_id': '82b8468a-7fb0-44f9-8532-48957dcc3d7e', 'status': 'submitted'}, 'tier_2': {'record_id': 'ac48ffc3-669e-4ec4-96fd-f959c5668a03', 'status': 'submitted'}}

repeating the same submission before 1 hours has passed (This should fail with 2 duplicates)

>>> print(status)
{'tier_1': {'status': 'failed', 'error': 'Failed to meter bill dimensions: Status: Duplicate Message: This usage event already exist.'}, 'tier_2': {'status': 'failed', 'error': 'Failed to meter bill dimensions: Status: Duplicate Message: This usage event already exist.'}}

and the logged errors:

Unable to log metered billing record: {'status': 'Duplicate', 'messageTime': '2023-07-27T19:29:38.6479191Z', 'error': {'additionalInfo': {'acceptedMessage': {'usageEventId': '82b8468a-7fb0-44f9-8532-48957dcc3d7e', 'status': 'Duplicate', 'messageTime': '2023-07-27T19:17:30.6099697Z', 'resourceId': 'bcccd3ed-e36b-4f51-87db-58ee1105f5c7', 'resourceUri': '/subscriptions/5f40eec9-a9be-4851-90c1-621e6d65df81/resourceGroups/kberger/providers/Microsoft.ContainerService/managedclusters/kberger-test-aks-cluster/providers/Microsoft.KubernetesConfiguration/extensions/kbergervoteapp', 'quantity': 1.0, 'dimension': 'tier_1', 'effectiveStartTime': '2023-07-27T19:13:42.772725', 'planId': 'kberger-nv-custom-silver'}}, 'message': 'This usage event already exist.', 'code': 'Conflict'}, 'resourceUri': '/subscriptions/5f40eec9-a9be-4851-90c1-621e6d65df81/resourceGroups/kberger/providers/Microsoft.ContainerService/managedclusters/kberger-test-aks-cluster/providers/Microsoft.KubernetesConfiguration/extensions/kbergervoteapp', 'quantity': 1.0, 'dimension': 'tier_1', 'effectiveStartTime': '2023-07-27T19:13:42.772725', 'planId': 'kberger-nv-custom-silver'}
Unable to log metered billing record: {'status': 'Duplicate', 'messageTime': '2023-07-27T19:29:38.6322895Z', 'error': {'additionalInfo': {'acceptedMessage': {'usageEventId': 'ac48ffc3-669e-4ec4-96fd-f959c5668a03', 'status': 'Duplicate', 'messageTime': '2023-07-27T19:17:30.6099697Z', 'resourceId': 'bcccd3ed-e36b-4f51-87db-58ee1105f5c7', 'resourceUri': '/subscriptions/5f40eec9-a9be-4851-90c1-621e6d65df81/resourceGroups/kberger/providers/Microsoft.ContainerService/managedclusters/kberger-test-aks-cluster/providers/Microsoft.KubernetesConfiguration/extensions/kbergervoteapp', 'quantity': 1.0, 'dimension': 'tier_2', 'effectiveStartTime': '2023-07-27T19:14:35.469159', 'planId': 'kberger-nv-custom-silver'}}, 'message': 'This usage event already exist.', 'code': 'Conflict'}, 'resourceUri': '/subscriptions/5f40eec9-a9be-4851-90c1-621e6d65df81/resourceGroups/kberger/providers/Microsoft.ContainerService/managedclusters/kberger-test-aks-cluster/providers/Microsoft.KubernetesConfiguration/extensions/kbergervoteapp', 'quantity': 1.0, 'dimension': 'tier_2', 'effectiveStartTime': '2023-07-27T19:14:35.469159', 'planId': 'kberger-nv-custom-silver'}
