### PR TITLE
Switch build

### DIFF
--- a/csp-billing-adapter-microsoft.spec
+++ b/csp-billing-adapter-microsoft.spec
@@ -15,9 +15,8 @@
 # Please submit bugfixes or comments via https://bugs.opensuse.org/
 #
 
-%{?!python_module:%define python_module() python-%{**} python3-%{**}}
-%global skip_python2 1
-%define pythons python3
+%{?sle15_python_module_pythons}
+
 Name:           csp-billing-adapter-microsoft
 Version:        0.2.1
 Release:        0
@@ -28,9 +27,11 @@ URL:            https://github.com/SUSE-Enceladus/%{name}
 Source:         https://files.pythonhosted.org/packages/source/c/%{name}/%{name}-%{version}.tar.gz
 BuildRequires:  fdupes
 BuildRequires:  python-rpm-macros
-BuildRequires:  %{python_module setuptools}
-BuildRequires:  %{python_module pluggy}
 BuildRequires:  %{python_module csp-billing-adapter}
+BuildRequires:  %{python_module pip}
+BuildRequires:  %{python_module pluggy}
+BuildRequires:  %{python_module setuptools}
+BuildRequires:  %{python_module wheel}
 %if %{with test}
 BuildRequires:  %{python_module pytest}
 BuildRequires:  %{python_module coverage}
@@ -50,10 +51,10 @@ metering of usage in Microsoft Azure.
 %autosetup -n %{name}-%{version}
 
 %build
-%python_build
+%pyproject_wheel
 
 %install
-%python_install
+%pyproject_install
 %python_expand %fdupes %{buildroot}%{$python_sitelib}
 
 %check


### PR DESCRIPTION
Switch the build for SLE to Python 3.11. Support multiple Python builds based on project setup and switch to wheel build.