### PR TITLE
Add obsoletes to spec file

### DIFF
--- a/csp-billing-adapter-microsoft.spec
+++ b/csp-billing-adapter-microsoft.spec
@@ -41,6 +41,7 @@ Requires:       python-setuptools
 Requires:       python-pluggy
 Requires:       python-csp-billing-adapter
 BuildArch:      noarch
+Obsoletes:      python3-csp-billing-adapter-microsoft < %{version}
 %python_subpackages
 
 %description


### PR DESCRIPTION
The package builds for python 3.## version instead of only python3